### PR TITLE
use HEAD request in Checking()

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -36,7 +36,7 @@ func (p *Pget) Checking() error {
 	client := http.Client{
 		Timeout: time.Duration(p.timeout) * time.Second,
 	}
-	res, err := client.Get(url)
+	res, err := client.Head(url)
 	if err != nil {
 		return errors.Wrap(err, "failed to head request: "+url)
 	}


### PR DESCRIPTION
Hi.
pget requests a GET at first in Checking(). But I think it should be a HEAD request.
