### PR TITLE
Evaluate ContentLength as int

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -85,12 +85,11 @@ func (p *Pget) CheckMirrors(ctx context.Context, url string, ch *Ch) {
 	}
 
 	// get of ContentLength
-	size := uint(res.ContentLength)
-	if size <= 0 {
+	if res.ContentLength <= 0 {
 		ch.Err <- errors.New("invalid content length")
-	} else {
-		ch.Size <- size
+		return
 	}
+	ch.Size <- uint(res.ContentLength)
 }
 
 // Download method distributes the task to each goroutine for each URL


### PR DESCRIPTION
If Content-Length is not shown on the header, `res.ContentLength` would be `-1` (https://golang.org/pkg/net/http/#Response)  
If we cast it to `uint`, it become a max value of `uint`, so we have to evaluate it as `int64`
