### PR TITLE
fixed -p options behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ This is an example to download [linux kernel](https://www.kernel.org/). It will 
 
 ![pget](https://user-images.githubusercontent.com/6500104/147878414-321c57ad-cff2-40f3-b2a4-12c30ff1363f.gif)
 
+
+## Disclaimer
+
+This program comes with no warranty. You must use this program at your own risk.
+
 ## Installation
 
 ### Homebrew
@@ -47,6 +52,12 @@ If you have created such as this file
 You can do this
 
     cat list.txt | pget -p 2
+
+### Note
+
+The case is increasing that if you use multiple connections for a single URL does not increase the download speed with the spread of CDNs.
+
+I recommend to use multiple mirrors simultaneously for faster downloads (And the number of connections is 1 for each).
 
 ## Options
 
@@ -83,10 +94,6 @@ pget -p 6   10.54s user 34.52s system 25% cpu 2:56.93 total
 ## Binary
 
 You can download from [here](https://github.com/Code-Hex/pget/releases)
-
-## Disclaimer
-
-This program comes with no warranty. You must use this program at your own risk.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Install
 
 ## Synopsis
 
-    % pget -p 6 URL 
-    % pget -p 6 MIRROR1 MIRROR2 MIRROR3
+This example will be used 2 connections per URL.
+
+    $ pget -p 2 MIRROR1 MIRROR2 MIRROR3
 
 If you have created such as this file
 
@@ -45,14 +46,14 @@ If you have created such as this file
 
 You can do this
 
-    cat list.txt | pget -p 6
+    cat list.txt | pget -p 2
 
 ## Options
 
 ```
   Options:
   -h,  --help                   print usage and exit
-  -p,  --procs <num>            split ratio to download file
+  -p,  --procs <num>            the number of connections for a single URL (default 1)
   -o,  --output <filename>      output file to <filename>
   -t,  --timeout <seconds>      timeout of checking request in seconds
   -u,  --user-agent <agent>     identify as <agent>

--- a/option.go
+++ b/option.go
@@ -11,14 +11,14 @@ import (
 
 // Options struct for parse command line arguments
 type Options struct {
-	Help      bool   `short:"h" long:"help"`
-	Procs     int    `short:"p" long:"procs"`
-	Output    string `short:"o" long:"output"`
-	Timeout   int    `short:"t" long:"timeout" default:"10"`
-	UserAgent string `short:"u" long:"user-agent"`
-	Referer   string `short:"r" long:"referer"`
-	Update    bool   `long:"check-update"`
-	Trace     bool   `long:"trace"`
+	Help          bool   `short:"h" long:"help"`
+	NumConnection int    `short:"p" long:"procs" default:"1"`
+	Output        string `short:"o" long:"output"`
+	Timeout       int    `short:"t" long:"timeout" default:"10"`
+	UserAgent     string `short:"u" long:"user-agent"`
+	Referer       string `short:"r" long:"referer"`
+	Update        bool   `long:"check-update"`
+	Trace         bool   `long:"trace"`
 }
 
 func (opts *Options) parse(argv []string, version string) ([]string, error) {
@@ -41,7 +41,7 @@ func (opts Options) usage(version string) []byte {
 		`Usage: pget [options] URL
   Options:
   -h,  --help                   print usage and exit
-  -p,  --procs <num>            split ratio to download file
+  -p,  --procs <num>            the number of connections for a single URL (default 1)
   -o,  --output <filename>      output file to <filename>
   -t,  --timeout <seconds>      timeout of checking request in seconds (default 10s)
   -u,  --user-agent <agent>     identify as <agent>

--- a/pget.go
+++ b/pget.go
@@ -88,10 +88,6 @@ func (pget *Pget) Run(ctx context.Context, version string, args []string) error 
 
 // Ready method define the variables required to Download.
 func (pget *Pget) Ready(version string, args []string) error {
-	if procs := os.Getenv("GOMAXPROCS"); procs == "" {
-		runtime.GOMAXPROCS(pget.Procs)
-	}
-
 	opts, err := pget.parseOptions(args, version)
 	if err != nil {
 		return errors.Wrap(errTop(err), "failed to parse command line args")
@@ -101,10 +97,6 @@ func (pget *Pget) Ready(version string, args []string) error {
 		pget.Trace = opts.Trace
 	}
 
-	if opts.Procs > 2 {
-		pget.Procs = opts.Procs
-	}
-
 	if opts.Timeout > 0 {
 		pget.timeout = opts.Timeout
 	}
@@ -112,6 +104,8 @@ func (pget *Pget) Ready(version string, args []string) error {
 	if err := pget.parseURLs(); err != nil {
 		return errors.Wrap(err, "failed to parse of url")
 	}
+
+	pget.Procs = opts.NumConnection * len(pget.URLs)
 
 	if opts.Output != "" {
 		pget.Output = opts.Output


### PR DESCRIPTION
- changed `-p` option behavior

Currently, the more mirror URLs you specify, the faster you get.
