### PR TITLE
docs: update to use homebrew-core tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ This program comes with no warranty. You must use this program at your own risk.
 
 ### Homebrew
 
-	brew update
-	brew install Code-Hex/tap/pget
+    $ brew install pget
 
 ### Go
 


### PR DESCRIPTION
I have [filed a PR](https://github.com/Homebrew/homebrew-core/pull/101884) including this formula into the homebrew-core. Updating the docs to use the homebrew-core tap. 