### PR TITLE
fix: fix partial file path

### DIFF
--- a/download.go
+++ b/download.go
@@ -34,10 +34,7 @@ type task struct {
 }
 
 func (t *task) destPath() string {
-	return filepath.Join(
-		t.PartialDir,
-		fmt.Sprintf("%s.%d.%d", t.Filename, t.Procs, t.ID),
-	)
+	return getPartialFilePath(t.PartialDir, t.Filename, t.Procs, t.ID)
 }
 
 func (t *task) String() string {
@@ -79,10 +76,7 @@ func assignTasks(c *assignTasksConfig) []*task {
 
 		r := makeRange(i, c.Procs, c.TaskSize, c.ContentLength)
 
-		partName := filepath.Join(
-			c.PartialDir,
-			fmt.Sprintf("%s.%d.%d", c.Filename, c.Procs, i),
-		)
+		partName := getPartialFilePath(c.PartialDir, c.Filename, c.Procs, i)
 
 		if info, err := os.Stat(partName); err == nil {
 			infosize := info.Size()
@@ -270,8 +264,8 @@ func bindFiles(c *DownloadConfig, partialDir string) error {
 	}
 
 	for i := 0; i < c.Procs; i++ {
-		name := fmt.Sprintf("%s/%s.%d.%d", partialDir, c.Filename, c.Procs, i)
-		if err := copyFn(name); err != nil {
+		partialFilename := getPartialFilePath(partialDir, c.Filename, c.Procs, i)
+		if err := copyFn(partialFilename); err != nil {
 			return err
 		}
 	}

--- a/util.go
+++ b/util.go
@@ -13,6 +13,14 @@ func getPartialDirname(targetDir, filename string, procs int) string {
 	return filepath.Join(targetDir, fmt.Sprintf("_%s.%d", filename, procs))
 }
 
+// getPartialFilePath returns the path of the partial file
+func getPartialFilePath(targetDir, filename string, id, procs int) string {
+	return filepath.Join(
+		targetDir,
+		fmt.Sprintf("%s.%d.%d", filename, procs, id),
+	)
+}
+
 // checkProgress In order to confirm the degree of progress
 func checkProgress(dirname string) (int64, error) {
 	return subDirsize(dirname)


### PR DESCRIPTION
- should use same func generate partial file path
- should use `filepath.Join` to solve cross-platform path
https://github.com/Code-Hex/pget/blob/8f357a2bbbf99e1574c2589c38373ae0d4ad88d1/download.go#L273 